### PR TITLE
Fix: forbidden casts and LTO compatability improvements

### DIFF
--- a/lib/cm3/vector.c
+++ b/lib/cm3/vector.c
@@ -36,7 +36,7 @@ int main(void);
 void blocking_handler(void);
 void null_handler(void);
 
-__attribute__ ((section(".vectors")))
+__attribute__((section(".vectors"), used))
 vector_table_t vector_table = {
 	.initial_sp_value = &_stack,
 	.reset = reset_handler,
@@ -59,7 +59,7 @@ vector_table_t vector_table = {
 	}
 };
 
-void __attribute__ ((weak)) reset_handler(void)
+void __attribute__((weak, used)) reset_handler(void)
 {
 	volatile unsigned *src, *dest;
 	funcp_t *fp;

--- a/lib/cortex-m-generic.ld
+++ b/lib/cortex-m-generic.ld
@@ -43,7 +43,7 @@ ENTRY(reset_handler)
 SECTIONS
 {
 	.text : {
-		*(.vectors)	/* Vector table */
+		KEEP(*(.vectors)) /* Vector table */
 		*(.text*)	/* Program code */
 		. = ALIGN(4);
 		*(.rodata*)	/* Read-only data */
@@ -122,4 +122,3 @@ SECTIONS
 }
 
 PROVIDE(_stack = ORIGIN(ram) + LENGTH(ram));
-

--- a/lib/stm32/common/st_usbfs_core.c
+++ b/lib/stm32/common/st_usbfs_core.c
@@ -100,8 +100,7 @@ void st_usbfs_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 	if (dir || (addr == 0)) {
 		USB_SET_EP_TX_ADDR(addr, dev->pm_top);
 		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
-			    (void *)callback;
+			dev->user_callback_ctr[addr][USB_TRANSACTION_IN] = callback;
 		}
 		USB_CLR_EP_TX_DTOG(addr);
 		USB_SET_EP_TX_STAT(addr, USB_EP_TX_STAT_NAK);
@@ -113,8 +112,7 @@ void st_usbfs_ep_setup(usbd_device *dev, uint8_t addr, uint8_t type,
 		USB_SET_EP_RX_ADDR(addr, dev->pm_top);
 		realsize = st_usbfs_set_ep_rx_bufsize(dev, addr, max_size);
 		if (callback) {
-			dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
-			    (void *)callback;
+			dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] = callback;
 		}
 		USB_CLR_EP_RX_DTOG(addr);
 		USB_SET_EP_RX_STAT(addr, USB_EP_RX_STAT_VALID);

--- a/lib/stm32/st_usbfs_v2.c
+++ b/lib/stm32/st_usbfs_v2.c
@@ -69,20 +69,22 @@ void st_usbfs_copy_from_pm(void *buf, const volatile void *vPM, uint16_t len)
 	uint8_t odd = len & 1;
 	len >>= 1;
 
-	if (((uintptr_t) buf) & 0x01) {
+	if (((uintptr_t)buf) & 0x01) {
+		uint8_t *dest = (uint8_t *)buf;
 		for (; len; PM++, len--) {
 			uint16_t value = *PM;
-			*(uint8_t *) buf++ = value;
-			*(uint8_t *) buf++ = value >> 8;
+			*(uint8_t *)dest++ = value;
+			*(uint8_t *)dest++ = value >> 8;
 		}
 	} else {
-		for (; len; PM++, buf += 2, len--) {
-			*(uint16_t *) buf = *PM;
+		uint16_t *dest = (uint16_t *)buf;
+		for (; len; PM++, dest++, len--) {
+			*dest = *PM;
 		}
 	}
 
 	if (odd) {
-		*(uint8_t *) buf = *(uint8_t *) PM;
+		*(uint8_t *)buf = *(uint8_t *)PM;
 	}
 }
 

--- a/lib/usb/usb_dwc_common.c
+++ b/lib/usb/usb_dwc_common.c
@@ -93,8 +93,7 @@ void dwc_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		    | (addr << 22) | max_size;
 
 		if (callback) {
-			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_IN] =
-			    (void *)callback;
+			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_IN] = callback;
 		}
 	}
 
@@ -107,8 +106,7 @@ void dwc_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		    OTG_DOEPCTLX_SD0PID | (type << 18) | max_size;
 
 		if (callback) {
-			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] =
-			    (void *)callback;
+			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] = callback;
 		}
 	}
 }

--- a/lib/usb/usb_lm4f.c
+++ b/lib/usb/usb_lm4f.c
@@ -264,8 +264,7 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_TXFIFOSZ = reg8;
 		USB_TXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
 		if (callback) {
-			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_IN] =
-			(void *)callback;
+			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_IN] = callback;
 		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
 			USB_TXCSRH(ep) |= USB_TXCSRH_ISO;
@@ -277,8 +276,7 @@ static void lm4f_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type,
 		USB_RXFIFOSZ = reg8;
 		USB_RXFIFOADD = ((usbd_dev->fifo_mem_top) >> 3);
 		if (callback) {
-			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_OUT] =
-			(void *)callback;
+			usbd_dev->user_callback_ctr[ep][USB_TRANSACTION_OUT] = callback;
 		}
 		if (type == USB_ENDPOINT_ATTR_ISOCHRONOUS) {
 			USB_RXCSRH(ep) |= USB_RXCSRH_ISO;

--- a/lib/usb/usb_lm4f.c
+++ b/lib/usb/usb_lm4f.c
@@ -376,15 +376,16 @@ static uint16_t lm4f_ep_write_packet(usbd_device *usbd_dev, uint8_t addr,
 	 * the reads are downgraded to 8-bit in hardware. We lose a bit of
 	 * performance, but we don't crash.
 	 */
+	const uint8_t *const data = (const uint8_t *)buf;
 	for (i = 0; i < (len & ~0x3); i += 4) {
-		USB_FIFO32(ep) = *((uint32_t *)(buf + i));
+		USB_FIFO32(ep) = *((uint32_t *)(data + i));
 	}
 	if (len & 0x2) {
-		USB_FIFO16(ep) = *((uint16_t *)(buf + i));
+		USB_FIFO16(ep) = *((uint16_t *)(data + i));
 		i += 2;
 	}
 	if (len & 0x1) {
-		USB_FIFO8(ep)  = *((uint8_t *)(buf + i));
+		USB_FIFO8(ep) = *((uint8_t *)(data + i));
 		i += 1;
 	}
 
@@ -424,15 +425,16 @@ static uint16_t lm4f_ep_read_packet(usbd_device *usbd_dev, uint8_t addr,
 	 * the writes are downgraded to 8-bit in hardware. We lose a bit of
 	 * performance, but we don't crash.
 	 */
+	uint8_t *const data = (uint8_t *)buf;
 	for (len = 0; len < (rlen & ~0x3); len += 4) {
-		*((uint32_t *)(buf + len)) = USB_FIFO32(ep);
+		*((uint32_t *)(data + len)) = USB_FIFO32(ep);
 	}
 	if (rlen & 0x2) {
-		*((uint16_t *)(buf + len)) = USB_FIFO16(ep);
+		*((uint16_t *)(data + len)) = USB_FIFO16(ep);
 		len += 2;
 	}
 	if (rlen & 0x1) {
-		*((uint8_t *)(buf + len)) = USB_FIFO8(ep);
+		*((uint8_t *)(data + len)) = USB_FIFO8(ep);
 	}
 
 	if (ep == 0) {


### PR DESCRIPTION
This PR aims to improve our standards conformance and LTO compatability.

ISO C forbids casting function points to or from `void *` as the size of a function pointer is allowed to be different from the size of a data pointer, the library should never have been doing this and especially as the casts aren't even required, so we eliminate them for all devices BMD compiles for.

It is an error to do pointer arithmetic on a void pointer - `sizeof(void)` has no standards-set size, and the operation is meaningless. Luckily all instances of this are trivially convertible to using typed pointers.

LTO requires we mark the vector table, reset vector and vector table's section all used/keep so it doesn't eliminate them due to nothing it can see calling into them.