### PR TITLE
fix: Fixed typo in meson.build for gcc warning option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,7 @@ extended_warnings = [
 	'-Wstringop-overflow',
 	'-Wunknown-pragmas',
 	'-Wunsafe-loop-optimizations',
-	'-Wunsuffixed-float-constant',
+	'-Wunsuffixed-float-constants',
 	'-Wunused-const-variable=2',
 	'-Wunused-local-typedefs',
 	'-Wunused',


### PR DESCRIPTION
Fixed typo in file ./meson.build for gcc warning option
Changed line/statement from
-Wunsuffixed-float-constant
to
-Wunsuffixed-float-constants
