### PR TITLE
fix: Fixed warning: unsuffixed floating constant

### DIFF
--- a/lib/lm4f/rcc.c
+++ b/lib/lm4f/rcc.c
@@ -372,7 +372,7 @@ void rcc_change_pll_divisor(uint8_t pll_div400)
 	/* Disable PLL bypass to derive the system clock from the PLL clock */
 	rcc_pll_bypass_disable();
 	/* Update the system clock frequency for housekeeping */
-	lm4f_rcc_sysclk_freq = (uint32_t)400000000 / pll_div400;
+	lm4f_rcc_sysclk_freq = 400000000U / (uint32_t)pll_div400;
 }
 
 /**

--- a/lib/lm4f/rcc.c
+++ b/lib/lm4f/rcc.c
@@ -372,7 +372,7 @@ void rcc_change_pll_divisor(uint8_t pll_div400)
 	/* Disable PLL bypass to derive the system clock from the PLL clock */
 	rcc_pll_bypass_disable();
 	/* Update the system clock frequency for housekeeping */
-	lm4f_rcc_sysclk_freq = (uint32_t)400E6 / pll_div400;
+	lm4f_rcc_sysclk_freq = (uint32_t)400000000 / pll_div400;
 }
 
 /**

--- a/lib/stm32/f1/rcc.c
+++ b/lib/stm32/f1/rcc.c
@@ -83,9 +83,9 @@ const struct rcc_clock_scale rcc_hse_configs[RCC_CLOCK_HSE_END] = {
 		.adcpre = RCC_CFGR_ADCPRE_DIV6,
 		.flash_waitstates = 2,
 		.prediv1 = RCC_CFGR2_PREDIV_DIV2,
-		.ahb_frequency = 72e6,
-		.apb1_frequency = 36e6,
-		.apb2_frequency = 72e6,
+		.ahb_frequency = 72000000,
+		.apb1_frequency = 36000000,
+		.apb2_frequency = 72000000,
 	},
 	{
 		/* hse25 to 72, this was a f105 config originally! intention preserved */
@@ -101,9 +101,9 @@ const struct rcc_clock_scale rcc_hse_configs[RCC_CLOCK_HSE_END] = {
 		.pll2_mul = RCC_CFGR2_PLL2MUL_PLL2_CLK_MUL8,
 		.prediv2 = RCC_CFGR2_PREDIV2_DIV5,
 		.usbpre = RCC_CFGR_USBPRE_PLL_VCO_CLK_DIV3,
-		.ahb_frequency = 72e6,
-		.apb1_frequency = 36e6,
-		.apb2_frequency = 72e6,
+		.ahb_frequency = 72000000,
+		.apb1_frequency = 36000000,
+		.apb2_frequency = 72000000,
 	},
 	{
 		/* hse8, pll to 24 (f100 value line max) */
@@ -115,9 +115,9 @@ const struct rcc_clock_scale rcc_hse_configs[RCC_CLOCK_HSE_END] = {
 		.adcpre = RCC_CFGR_ADCPRE_DIV2,
 		.flash_waitstates = 0,
 		.prediv1 = RCC_CFGR2_PREDIV_NODIV,
-		.ahb_frequency = 24e6,
-		.apb1_frequency = 24e6,
-		.apb2_frequency = 24e6,
+		.ahb_frequency = 24000000,
+		.apb1_frequency = 24000000,
+		.apb2_frequency = 24000000,
 	},
 	{
 		/* hse8, pll to 72 */
@@ -129,9 +129,9 @@ const struct rcc_clock_scale rcc_hse_configs[RCC_CLOCK_HSE_END] = {
 		.adcpre = RCC_CFGR_ADCPRE_DIV8,
 		.flash_waitstates = 2,
 		.prediv1 = RCC_CFGR2_PREDIV_NODIV,
-		.ahb_frequency = 72e6,
-		.apb1_frequency = 36e6,
-		.apb2_frequency = 72e6,
+		.ahb_frequency = 72000000,
+		.apb1_frequency = 36000000,
+		.apb2_frequency = 72000000,
 	},
 };
 
@@ -146,9 +146,9 @@ const struct rcc_clock_scale rcc_hsi_configs[RCC_CLOCK_HSI_END] = {
 		.ppre2 = RCC_CFGR_PPRE_NODIV,
 		.adcpre = RCC_CFGR_ADCPRE_DIV2,
 		.flash_waitstates = 0,
-		.ahb_frequency	= 24e6,
-		.apb1_frequency = 24e6,
-		.apb2_frequency = 24e6,
+		.ahb_frequency	= 24000000,
+		.apb1_frequency = 24000000,
+		.apb2_frequency = 24000000,
 	},
 	{
 		/* hsi to 48Mhz, allows usb, but out of spec */
@@ -161,9 +161,9 @@ const struct rcc_clock_scale rcc_hsi_configs[RCC_CLOCK_HSI_END] = {
 		.adcpre = RCC_CFGR_ADCPRE_DIV8,
 		.usbpre = RCC_CFGR_USBPRE_PLL_CLK_NODIV,
 		.flash_waitstates = 1,
-		.ahb_frequency	= 48e6,
-		.apb1_frequency = 24e6,
-		.apb2_frequency = 48e6,
+		.ahb_frequency	= 48000000,
+		.apb1_frequency = 24000000,
+		.apb2_frequency = 48000000,
 	},
 	{
 		/* hsi to 64Mhz, max possible from hsi */
@@ -175,9 +175,9 @@ const struct rcc_clock_scale rcc_hsi_configs[RCC_CLOCK_HSI_END] = {
 		.ppre2 = RCC_CFGR_PPRE_NODIV,
 		.adcpre = RCC_CFGR_ADCPRE_DIV8,
 		.flash_waitstates = 2,
-		.ahb_frequency	= 64e6,
-		.apb1_frequency = 32e6,
-		.apb2_frequency = 64e6,
+		.ahb_frequency	= 64000000,
+		.apb1_frequency = 32000000,
+		.apb2_frequency = 64000000,
 	},
 };
 

--- a/lib/stm32/f3/rcc.c
+++ b/lib/stm32/f3/rcc.c
@@ -79,9 +79,9 @@ const struct rcc_clock_scale rcc_hse8mhz_configs[] = {
 		.hpre = RCC_CFGR_HPRE_NODIV,
 		.ppre1 = RCC_CFGR_PPRE_DIV2,
 		.ppre2 = RCC_CFGR_PPRE_NODIV,
-		.ahb_frequency = 72e6,
-		.apb1_frequency = 36e6,
-		.apb2_frequency = 72e6,
+		.ahb_frequency = 72000000,
+		.apb1_frequency = 36000000,
+		.apb2_frequency = 72000000,
 	}
 };
 


### PR DESCRIPTION
warning: unsuffixed floating constant [-Wunsuffixed-float-constants]

**Note!** Make sure sure to carefully check what I have done. I am no expert in the C language (or programming in general). If it looks wired, it probably is, and the PR should be rejected.

**Reason behind my solution**
C-language, or at least Gnu gcc, does not support exponents for integer constants, therefor integer constant expressions need to be changed to plain numbers (e.g. 72e6 --> 72000000).

The project builds without errors and warnings (that is the only test I can perform).

Blackmagic repo, Issue  #1762
