### PR TITLE
Feature: usart_get_baudrate for STM32 common USART and TM4C UART

### DIFF
--- a/include/libopencm3/lm4f/uart.h
+++ b/include/libopencm3/lm4f/uart.h
@@ -443,6 +443,7 @@ enum uart_fifo_tx_trigger_level {
 BEGIN_DECLS
 
 void uart_set_baudrate(uint32_t uart, uint32_t baud);
+uint32_t uart_get_baudrate(uint32_t uart);
 void uart_set_databits(uint32_t uart, uint8_t databits);
 uint8_t uart_get_databits(uint32_t uart);
 void uart_set_stopbits(uint32_t uart, uint8_t stopbits);

--- a/include/libopencm3/stm32/common/usart_common_all.h
+++ b/include/libopencm3/stm32/common/usart_common_all.h
@@ -99,6 +99,7 @@ specific memorymap.h header before including this header file.*/
 BEGIN_DECLS
 
 void usart_set_baudrate(uint32_t usart, uint32_t baud);
+uint32_t usart_get_baudrate(uint32_t usart);
 void usart_set_databits(uint32_t usart, uint32_t bits);
 uint32_t usart_get_databits(uint32_t usart);
 void usart_set_stopbits(uint32_t usart, uint32_t stopbits);

--- a/lib/lm4f/uart.c
+++ b/lib/lm4f/uart.c
@@ -131,6 +131,25 @@ void uart_set_baudrate(uint32_t uart, uint32_t baud)
 }
 
 /**
+ * \brief Get UART baudrate
+ *
+ * @param[in] uart UART block register address base @ref uart_reg_base
+ * @return Baud rate in bits per second (bps)
+ */
+uint32_t uart_get_baudrate(uint32_t uart)
+{
+	/* Are we running off the internal clock or system clock? */
+	const uint32_t clock = UART_CC(uart) == UART_CC_CS_PIOSC ? 16000000U : rcc_get_system_clock_frequency();
+
+	/* Read back divisor parts. Baudrate = clock/16 / (ibrd+fbrd/64). */
+	const uint16_t ibrd = UART_IBRD(uart);
+	const uint16_t fbrd = UART_FBRD(uart);
+	uint32_t div = ibrd * 64U + fbrd;
+	/* Recalculate the actual baudrate. Note that 4 comes from 1/(16/64). */
+	return 4U * clock / div;
+}
+
+/**
  * \brief Set UART databits
  *
  * @param[in] uart UART block register address base @ref uart_reg_base

--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -95,6 +95,39 @@ void usart_set_baudrate(uint32_t usart, uint32_t baud)
 }
 
 /*---------------------------------------------------------------------------*/
+/** @brief USART Get Baudrate.
+
+@param[in] usart unsigned 32 bit. USART block register address base @ref usart_reg_base
+@returns baud unsigned 32 bit. Baud rate specified in Hz.
+*/
+
+uint32_t usart_get_baudrate(uint32_t usart)
+{
+	uint32_t clock = rcc_get_usart_clk_freq(usart);
+	const uint32_t reg_brr = USART_BRR(usart);
+
+#ifdef LPUART1
+	if (usart == LPUART1) {
+		return (256U * clock) / reg_brr;
+	}
+#endif
+
+#ifdef USART_CR1_OVER8
+	if (USART_CR1(usart) & USART_CR1_OVER8) {
+		/* Need to shift BRR[2:0] up before using the simple formula of 2*clock/BRR (Q12.4) */
+		const uint16_t div_mantissa = reg_brr & USART_BRR_UPPER_MASK;
+		const uint16_t div_fractional = (reg_brr & USART_BRR_LOWER_MASK) << 1U;
+		const uint16_t div_over8 = div_mantissa + div_fractional;
+		return (2U * clock) / div_over8;
+	} else {
+		return clock / reg_brr;
+	}
+#else
+	return clock / reg_brr;
+#endif
+}
+
+/*---------------------------------------------------------------------------*/
 /** @brief USART Set Word Length.
 
 The word length is set to 8 or 9 bits. Note that the last bit will be a parity


### PR DESCRIPTION
Implement library functions to compute effective U(S)ART baudrate as counterparts to `usart_set_baudrate()`.
This code is extracted from https://github.com/blackmagic-debug/blackmagic/pull/1864

TM4C seems to have an instance of ARM PrimeCell UART PL011. I cannot test my implementation as I don't have the hardware.

STM32F4 has USART v1 IP with OVER8 support (pending). The value in these functions is that they should handle OVER8 enabled/disabled differences in calculations. STM32F1 does not support OVER8 and can use this already. I remember testing on either bluepill or blackpill-f411ce, and I can test on these devices.

This is required for Blackmagic Debug Firmware to support reporting precise baud rates used in TraceSWO Async capture.