### PR TITLE
Fix: STM32 common USART: extend `usart_get_baudrate()` working range for LPUART

### DIFF
--- a/lib/stm32/common/usart_common_all.c
+++ b/lib/stm32/common/usart_common_all.c
@@ -97,6 +97,9 @@ void usart_set_baudrate(uint32_t usart, uint32_t baud)
 /*---------------------------------------------------------------------------*/
 /** @brief USART Get Baudrate.
 
+Note: For LPUART, baudrates over 2**24 (~16.7 Mbaud) may overflow
+the calculation and are therefore not supported by this function.
+
 @param[in] usart unsigned 32 bit. USART block register address base @ref usart_reg_base
 @returns baud unsigned 32 bit. Baud rate specified in Hz.
 */
@@ -108,7 +111,8 @@ uint32_t usart_get_baudrate(uint32_t usart)
 
 #ifdef LPUART1
 	if (usart == LPUART1) {
-		return (256U * clock) / reg_brr;
+		return (clock / reg_brr) * 256
+			+ ((clock % reg_brr) * 256) / reg_brr;
 	}
 #endif
 


### PR DESCRIPTION
This is a follow-up to blackmagic-debug/libopencm3#5.

The existing implementation would work for LSE-clocked LPUART at e.g. 9600 baud, but would overflow the calculation for `lpuart_ker_ck` above 2**24 Hz (16.7 MHz).
Use a smarter div-mod approach, like in set_baudrate, recommended by @zyp (asking review).

Please test correctness on hardware. Now it should work for e.g. 64MHz G071 (or G4, or H7). I don't have a unit test or a firmware test project, but I have some boards.