### PR TITLE
Fix/device_descriptor_fail_f4_windows

### DIFF
--- a/lib/usb/usb_dwc_common.c
+++ b/lib/usb/usb_dwc_common.c
@@ -372,12 +372,14 @@ void dwc_poll(usbd_device *usbd_dev)
 		_usbd_reset(usbd_dev);
 		return;
 	}
+#if defined(STM32H7)
 	if (intsts & OTG_GINTSTS_USBRST) {
 		/* Handle the /other/ USB Reset condition */
 		REBASE(OTG_GINTSTS) = OTG_GINTSTS_USBRST | OTG_GINTSTS_RSTDET;
 		dwc_endpoints_reset(usbd_dev);
 		return;
 	}
+#endif
 
 	/*
 	 * There is not always a global interrupt flag for transmit complete.


### PR DESCRIPTION
Fix failure of F4 platforms to supply a correct device descriptor on Windows.