### PR TITLE
stm32/l4: Excluded and commented extraneous vector_chipset.c

### DIFF
--- a/lib/stm32/l4/meson.build
+++ b/lib/stm32/l4/meson.build
@@ -42,7 +42,7 @@ libstm32l4_sources = files(
 	'i2c.c',
 	'pwr.c',
 	'rcc.c',
-	'vector_chipset.c',
+	#'vector_chipset.c', # This source is included by lib/dispatch/vector_chipset.c 
 
 )
 


### PR DESCRIPTION
Excludes the `vector_chipset.c` source which is already included by `lib/dispatch/vector_chipset.c`.